### PR TITLE
remove commons-csv dependency from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,6 @@
 			<version>${matsim.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-csv</artifactId>
-			<version>1.9.0</version>
-		</dependency>
-
 		<!-- Include the JUnit testing library -->
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
So that we depend directly only on matsim and contribs, while keeping other dependencies transitive. This way code examples can be easily copy/pasted to other projects depending on matsim-libs.