### PR TITLE
set up dependabot on 15.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Anytime a new matsim release is made, dependabot will pick it up and create a PR. Because of the maven numbering scheme (https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning), it will be weekly releases as they are considered higher/newer than PR releases.

BTW. Perhaps it is possible to exclude weekly releases and use PR releases, but then there is one more issue with the latter option: the PR versions are not monotonically increasing - some older PRs may be merged after newer ones.