### PR TITLE
mvn: only one matsim.version property declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,17 +10,8 @@
 	<description>MATSim code examples</description>
 
 	<properties>
-		<!--release:-->
-<!--		<matsim.version>14.0</matsim.version>-->
-
-		<!--stable build based on weekly releases (recommended):-->
-		<matsim.version>15.0-2023w01</matsim.version>
-
-<!--		I think we should leave this at PR builds for better stability.  Please pull up every time you see this.  kai, dec'20 -->
+		<!--stable build based on weekly (e.g. 15.0-PR2344), PR-based (e.g. 15.0-2023w01) or official (e.g. 14.0) releases -->
 		<matsim.version>15.0-PR2344</matsim.version>
-
-		<!--development head:-->
-		<matsim.version>15.0-SNAPSHOT</matsim.version>
 
 		<maven.compiler.release>17</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
We used to have several `<matsim.version>` declarations (all but one commented out). However, this may easily lead to situations when we uncomment more then one.

Currently, we have 3 (out of 4) uncommented by accident. Interestingly,
- the intention of the last edits was to switch to the middle one (i.e. `15.0-PR2344`)
- maven uses the last one (i.e. `15.0-SNAPSHOT`)
- dependabot bumps the first one (i.e. `15.0-2023w01`)

IMO we should only have one line, and adjust it when necessary.