### PR TITLE
add empty output dir

### DIFF
--- a/output/.gitignore
+++ b/output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/src/test/java/org/matsim/codeexamples/programming/demandGenerationWithFacilities/IntegrationTest.java
+++ b/src/test/java/org/matsim/codeexamples/programming/demandGenerationWithFacilities/IntegrationTest.java
@@ -34,7 +34,6 @@ public class IntegrationTest {
 	
 	@Rule public MatsimTestUtils utils = new MatsimTestUtils() ;
 
-	@SuppressWarnings("static-method")
 	@Test
 	public final void test() {
 		


### PR DESCRIPTION
Recently, builds started to fail without any clear cause (like a change in the repo):

https://github.com/matsim-org/matsim-code-examples/actions/runs/3934230183
https://github.com/matsim-org/matsim-code-examples/actions/runs/3930772480
https://github.com/matsim-org/matsim-code-examples/actions/runs/3913042189

It seems that many examples write output files to this folder, but not all of them create this output dir. Probably a change in the test execution order resulted in this failures.

==

Alternative solution to this issue: make sure that all examples always create this folder before writing output there.
